### PR TITLE
fix postgres encoding (should be utf8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM debian:jessie
 MAINTAINER Andrew Balakirev <balakirev.andrey@gmail.com>
 
+# make the "en_US.UTF-8" locale so postgres will be utf-8 enabled by default
+RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
+	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+RUN echo 'LANG="en_US.UTF-8"' >> /etc/default/locale
+
 #Install PostgreSQL-9.4
 RUN apt-get update && \
     apt-get install -y postgresql-9.4 postgresql-contrib pwgen && \
@@ -12,7 +17,7 @@ RUN echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/9.4/main/pg_hba.co
 RUN echo "listen_addresses='*'" >> /etc/postgresql/9.4/main/postgresql.conf
 
 # Add VOLUMEs to allow backup of config, logs and databases
-VOLUME	["/etc/postgresql", "/var/log/postgresql", "/var/lib/postgresql"]
+VOLUME ["/etc/postgresql", "/var/log/postgresql", "/var/lib/postgresql"]
 
 ADD modify_postgres_pass.sh ./modify_postgres_pass.sh
 ADD create_plyo.sh ./create_plyo.sh


### PR DESCRIPTION
@jifeon @AGresvig 
I found that our postgres server has wrong default encoding (`SQL_ASCII`) so `plyo` db has the same encoding, too. I think we should use `utf8` instead. 

After this fix our postgres installation will have `utf-8` as default encoding and `en_US` as default locale. We don't set these props explicitly so `plyo` db will be created with the same encoding and locale, too.

**ATTENTION!**
AFAIK, the only safe way to change encoding of the DB is to dump it, drop it and recreate from scratch.
