### PR TITLE
Publish db approach to OS - Tests for users permissions

### DIFF
--- a/database/test/expected/users.out.sql
+++ b/database/test/expected/users.out.sql
@@ -5,16 +5,81 @@
 set client_min_messages to 'warning';
 SET
 -- Clean up in case a prior test run failed
-drop table if exists test;
+drop table if exists users_test;
 DROP TABLE
--- viewpoint from admin user, it:
+drop table if exists users_test_2;
+DROP TABLE
+-------------------------------
+-- viewpoint from admin user --
+-------------------------------
 set session authorization admin;
 SET
--- should not be able to drop public schema
-drop schema public;
-psql:test/sql/users.sql:15: ERROR:  must be owner of schema public
+set search_path to test_schema;
+SET
+-- admin user:
+--------------
+-- should not be able to drop the schema
+drop schema test_schema;
+psql:test/sql/users.sql:22: ERROR:  must be owner of schema test_schema
 -- should be able to create a new table
-create table test (
+create table users_test (
   col integer
 );
 CREATE TABLE
+-- should be able to use DML
+insert into users_test (col) values (1);
+INSERT 0 1
+update users_test set col = 2 where col = 1;
+UPDATE 1
+select * from users_test;
+ col 
+-----
+   2
+(1 row)
+
+delete from users_test;
+DELETE 1
+-----------------------------
+-- viewpoint from app user --
+-----------------------------
+set session authorization app;
+SET
+-- app user:
+--------------
+-- should not be able to drop the schema
+drop schema test_schema;
+psql:test/sql/users.sql:44: ERROR:  must be owner of schema test_schema
+-- should not be able to create a new table
+create table users_test_2 (
+  col integer
+);
+psql:test/sql/users.sql:49: ERROR:  permission denied for schema test_schema
+LINE 1: create table users_test_2 (
+                     ^
+-- should not be able to remove existent one
+drop table users_test;
+psql:test/sql/users.sql:52: ERROR:  must be owner of relation users_test
+-- should not be able to alter existent table
+alter table users_test
+  add column col2 integer;
+psql:test/sql/users.sql:56: ERROR:  must be owner of relation users_test
+-- should be able to use DML
+insert into users_test (col) values (1);
+INSERT 0 1
+update users_test set col = 2 where col = 1;
+UPDATE 1
+select * from users_test;
+ col 
+-----
+   2
+(1 row)
+
+delete from users_test;
+DELETE 1
+-------------
+-- cleanup --
+-------------
+reset session authorization;
+RESET
+drop table users_test;
+DROP TABLE

--- a/database/test/sql/users.sql
+++ b/database/test/sql/users.sql
@@ -6,15 +6,64 @@
 set client_min_messages to 'warning';
 
 -- Clean up in case a prior test run failed
-drop table if exists test;
+drop table if exists users_test;
+drop table if exists users_test_2;
 
--- viewpoint from admin user, it:
+-------------------------------
+-- viewpoint from admin user --
+-------------------------------
 set session authorization admin;
+set search_path to test_schema;
 
--- should not be able to drop public schema
-drop schema public;
+-- admin user:
+--------------
+
+-- should not be able to drop the schema
+drop schema test_schema;
 
 -- should be able to create a new table
-create table test (
+create table users_test (
   col integer
 );
+
+-- should be able to use DML
+insert into users_test (col) values (1);
+update users_test set col = 2 where col = 1;
+select * from users_test;
+delete from users_test;
+
+-----------------------------
+-- viewpoint from app user --
+-----------------------------
+set session authorization app;
+
+-- app user:
+--------------
+
+-- should not be able to drop the schema
+drop schema test_schema;
+
+-- should not be able to create a new table
+create table users_test_2 (
+  col integer
+);
+
+-- should not be able to remove existent one
+drop table users_test;
+
+-- should not be able to alter existent table
+alter table users_test
+  add column col2 integer;
+
+-- should be able to use DML
+insert into users_test (col) values (1);
+update users_test set col = 2 where col = 1;
+select * from users_test;
+delete from users_test;
+
+-------------
+-- cleanup --
+-------------
+
+reset session authorization;
+drop table users_test;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ x-db_defaults: &db_defaults
     - POSTGRES_PASSWORD=password
     - ADMIN_PASS=password
     - APP_PASS=password
-    - DB_NAME=plyo
+    - DB_NAME=test_db
+    - SCHEMA_NAME=test_schema
   ports:
     - '5432:5432'
 


### PR DESCRIPTION
It continues https://github.com/plyo/plyo.postgres/pull/15 and https://github.com/plyo/plyo.postgres/pull/16

In this PR I've added tests for users' permissions. We have 3 roles in our image:
- postgres - root
- admin - admin user for specified schema, useful for migrations, has DDL rights
- app - user with DML only rights, useful to use from inside of application to mitigate possible damage by SQL injection

Of course these tests uncovered bugs, which were fixed. Also we do not use `public` schema anymore since it has some standard permissions for all users and I want all the right are specified explicitly.