### PR TITLE
PLYO-632 Support for dumping roles

### DIFF
--- a/backups/Dockerfile
+++ b/backups/Dockerfile
@@ -1,5 +1,4 @@
-FROM alpine
-RUN apk add --update bash postgresql && rm -rf /var/cache/apk/*
+FROM postgres:10.4-alpine
 
 VOLUME /backups
 

--- a/backups/docker-compose.yml
+++ b/backups/docker-compose.yml
@@ -13,32 +13,35 @@ services:
     build: .
     environment:
       # DB to dump
-      - DB_NAME=test_db
+      DB_NAME: test_db
 
       # DBs to dump
-      - DB_CONFIG_1=db-1:5432:*:postgres:password
-      - DB_CONFIG_2=db-2:5432:*:postgres:password
+      DB_CONFIG_1: db-1:5432:*:postgres:password
+      DB_CONFIG_2: db-2:5432:*:postgres:password
 
       # This dir will be created if it doesn't exist. This must be writable by the user the script is
       # running as.
-      - BACKUP_DIR=/backups/
+      BACKUP_DIR: /backups/
 
       # SETTINGS FOR ROTATED BACKUPS
 
       # Which day to take the weekly backup from (1-7 = Monday-Sunday)
-      - DAY_OF_WEEK_TO_KEEP=5
+      DAY_OF_WEEK_TO_KEEP: 5
 
       # Number of hours to keep daily backups
-      - DAYS_TO_KEEP_HOURLY=1
+      DAYS_TO_KEEP_HOURLY: 1
 
       # Number of days to keep daily backups
-      - DAYS_TO_KEEP_DAILY=7
+      DAYS_TO_KEEP_DAILY: 7
 
       # How many weeks to keep weekly backups
-      - WEEKS_TO_KEEP_WEEKLY=4
+      WEEKS_TO_KEEP_WEEKLY: 4
 
       # How many months to keep monthly backups
-      - MONTHS_TO_KEEP_MONTHLY=6
+      MONTHS_TO_KEEP_MONTHLY: 6
+
+      # Avoid dumping of existent roles to prevent password rewriting
+      IGNORE_DUMP_ROLES: \(admin\|app\|postgres\)
     volumes:
       - ./backups/:/backups/
       - ./src:/usr/src/app/

--- a/backups/src/pg_backup_rotated.sh
+++ b/backups/src/pg_backup_rotated.sh
@@ -14,6 +14,7 @@ function perform_backups()
 
     backup_date=`date +%Y-%m-%d`
     backup_file_path="${BACKUP_DIR}${backup_date}${suffix}".backup
+    backup_roles_file_path="${backup_file_path}_roles.out"
 
     if [ -e "${backup_file_path}" ]; then
         echo "${backup_file_path} already exists, skipping dump"
@@ -25,6 +26,7 @@ function perform_backups()
     if ! pg_dump -Fc -h "$db_host" -p "$db_port" -U postgres ${DB_NAME} -f ${backup_file_path}.in_progress; then
         echo "[!!ERROR!!] Failed to produce custom backup database ${DB_NAME}"
     else
+        pg_dumpall -r -h "$db_host" -p "$db_port" -U postgres -f ${backup_roles_file_path}
         mv ${backup_file_path}.in_progress ${backup_file_path}
         echo -e "\nDatabase backup complete!"
     fi

--- a/backups/src/pg_backup_rotated.sh
+++ b/backups/src/pg_backup_rotated.sh
@@ -26,8 +26,10 @@ function perform_backups()
     if ! pg_dump -Fc -h "$db_host" -p "$db_port" -U postgres ${DB_NAME} -f ${backup_file_path}.in_progress; then
         echo "[!!ERROR!!] Failed to produce custom backup database ${DB_NAME}"
     else
-        pg_dumpall -r -h "$db_host" -p "$db_port" -U postgres -f ${backup_roles_file_path}
+        pg_dumpall -r -h "$db_host" -p "$db_port" -U postgres -f ${backup_roles_file_path}.in_progress
+        cat ${backup_roles_file_path}.in_progress | grep -v ${IGNORE_DUMP_ROLES} > "${backup_roles_file_path}"
         mv ${backup_file_path}.in_progress ${backup_file_path}
+        rm -f ${backup_roles_file_path}.in_progress
         echo -e "\nDatabase backup complete!"
     fi
 }

--- a/publisher/start.sh
+++ b/publisher/start.sh
@@ -10,13 +10,18 @@ ${POSTGRES_IMAGE} tail -f /dev/null
 docker exec publishing_db_container mkdir /dumps
 backup_date=`date +%Y-%m-%d-%H:00`
 backup_file=${backup_date}${DUMP_NAME_SUFFIX}
+backup_roles_file=${backup_file}_roles.out
 
 if [ $(docker exec publishing_db_container test -e "/files/$backup_file" && echo $?) ];
 then
     docker exec publishing_db_container cp /files/${backup_file} /dumps/db.backup
+    docker exec publishing_db_container cp /files/${backup_roles_file} /dumps/db_roles.out
 
     # restore.sh will be executed at the moment of container's start
-    echo "pg_restore /dumps/db.backup -U postgres -d ${DB_NAME}" | (docker exec -i publishing_db_container sh -c "cat > restore.sh")
+    cat <<-EORESTORE | (docker exec -i publishing_db_container sh -c "cat > restore.sh")
+      psql -f /dumps/db_roles.out -U postgres
+      pg_restore /dumps/db.backup -U postgres -d ${DB_NAME}
+EORESTORE
 
     docker stop publishing_db_container
     docker commit $(docker ps -a -f name=publishing_db_container -q) ${DESTINATION_DOCKER_IMAGE}


### PR DESCRIPTION
- backups service now prepare 2 dumps - with data and with roles
- publisher cares about roles to be restored before data
- postgres version for backups updated to 10.4