### PR TITLE
PL-425 Fix sanitizer problem with empty dumps

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -3,7 +3,7 @@ COPY docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d/
 HEALTHCHECK --interval=5s --timeout=3s CMD pg_isready -d postgres -U postgres
 
 FROM postgres:10.4 as test
-RUN apt-get update && apt-get install -y make colordiff
+RUN apt-get update && apt-get install -y make colordiff netcat
 WORKDIR /app
 COPY docker-entrypoint-initdb.d/* /docker-entrypoint-initdb.d/
 COPY . /app

--- a/publisher/docker-compose.yml
+++ b/publisher/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - DOCKERHUB_LOGIN
       - DOCKERHUB_PASS
       - DUMP_NAME_SUFFIX=-prod-db-5432-hourly.backup
-      - POSTGRES_IMAGE=plyo/postgres:database-10.4-5.0.0-rc
+      - POSTGRES_IMAGE=plyo/postgres:database-10.4-5.1.0-rc
       - DUMPS_DIR
       - DESTINATION_DOCKER_IMAGE=registry.plyo.website/plyo/db-test:data
       - SCHEMA_NAME=test_schema

--- a/publisher/start.sh
+++ b/publisher/start.sh
@@ -61,7 +61,7 @@ EORESTORE
     log "Waiting 1 min for sanitizer to be initialized"
     for i in `seq 1 60`;
     do
-      docker exec sanitizing_db_container psql -U postgres -c "\t" &> /dev/null && db_initialized=1 && break
+      docker exec sanitizing_db_container nc -z localhost 5432 && db_initialized=1 && break
       echo -n .
       sleep 1
     done


### PR DESCRIPTION
Added netcat for database container for stronger check that postgres is up and running

TODO:
- [x] sanitizer should use `nc` to check is postgres is started or not
- [x] [commit to plyo.stacks](9f5d8cefe577f67b2ee26550fd7c53ace6d3e83c)